### PR TITLE
99/tc 499 implement update by query

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,6 +34,11 @@ Faceted Search
 .. autoclass:: FacetedSearch
    :members:
 
+Update By Query 
+----------------
+.. autoclass:: UpdateByQuery
+  :members:
+
 Mappings
 --------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -250,6 +250,54 @@ search class to simplify searching and filtering.
 
 You can find more details in the :ref:`faceted_search` chapter.
 
+
+Update By Query Example
+------------------------
+
+Let's resume the simple example of articles on a blog, and let's assume that each article has a number of likes.
+For this example, imagine we want to increment the number of likes by 1 for all articles that match a certain tag and do not match a certain description.
+Writing this as a ``dict``, we would have the following code:
+
+.. code:: python
+
+    from elasticsearch import Elasticsearch
+    client = Elasticsearch()
+
+    response = client.update_by_query(
+        index="my-index",
+        body={
+          "query": {
+            "bool": {
+              "must": [{"match": {"tag": "python"}}],
+              "must_not": [{"match": {"description": "beta"}}]
+            }
+          },
+          "script"={
+            "source": "ctx._source.likes++",
+            "lang": "painless"
+          }
+        },
+      )
+
+Using the DSL, we can now express this query as such: 
+
+.. code:: python
+
+    from elasticsearch import Elasticsearch
+    from elasticsearch_dsl import Search
+
+    client = Elasticsearch()
+    ubq = UpdateByQuery(using=client, index="my-index") \
+          .query("match", title="python")   \
+          .exclude("match", description="beta") \
+          .script(source="ctx._source.likes++", lang="painless")
+
+    response = ubq.execute()
+
+As you can see, the ``Update By Query`` object provides many of the savings offered
+by the ``Search`` object, and additionally allows one to update the results of the search
+based on a script assigned in the same manner.
+
 Migration from ``elasticsearch-py``
 -----------------------------------
 
@@ -299,6 +347,7 @@ Contents
    search_dsl
    persistence
    faceted_search
+   update_by_query
    api
    CONTRIBUTING
    Changelog

--- a/docs/search_dsl.rst
+++ b/docs/search_dsl.rst
@@ -1,3 +1,5 @@
+.. _search_dsl:
+
 Search DSL
 ==========
 

--- a/docs/update_by_query.rst
+++ b/docs/update_by_query.rst
@@ -1,0 +1,148 @@
+.. _update_by_query:
+
+Update By Query
+================
+
+The ``Update By Query`` object
+-------------------------------
+
+The ``Update By Query`` object enables the use of the 
+`_update_by_query <https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html>`_
+endpoint to perform an update on documents that match a search query.
+
+The object is implemented as a modification of the ``Search`` object, containing a 
+subset of its query methods, as well as a script method, which is used to make updates.
+
+The ``Update By Query`` object implements the following ``Search`` query types:
+  
+  * queries
+
+  * filters
+
+  * excludes
+
+For more information on queries, see the :ref:`search_dsl` chapter.
+
+Like the ``Search`` object, the API is designed to be chainable. This means that the ``Update By Query`` object
+is immutable: all changes to the object will result in a shallow copy being created which
+contains the changes. This means you can safely pass the ``Update By Query`` object to
+foreign code without fear of it modifying your objects as long as it sticks to
+the ``Update By Query`` object APIs.
+
+You can pass an instance of the low-level `elasticsearch client <https://elasticsearch-py.readthedocs.io/>`_ when
+instantiating the ``Update By Query`` object:
+
+.. code:: python
+
+    from elasticsearch import Elasticsearch
+    from elasticsearch_dsl import UpdateByQuery
+
+    client = Elasticsearch()
+
+    ubq = UpdateByQuery(using=client)
+
+You can also define the client at a later time (for more options see the
+:ref:`configuration` chapter):
+
+.. code:: python
+
+    ubq = ubq.using(client)
+
+.. note::
+
+    All methods return a *copy* of the object, making it safe to pass to
+    outside code.
+
+The API is chainable, allowing you to combine multiple method calls in one
+statement:
+
+.. code:: python
+
+    ubq = UpdateByQuery().using(client).query("match", title="python")
+
+To send the request to Elasticsearch:
+
+.. code:: python
+
+    response = ubq.execute()
+
+It should be noted, that there are limits to the chaining using the script method: calling script multiple times will 
+overwrite the previous value. That is, only a single script can be sent with a call. An attempt to use two scripts will 
+result in only the second script being stored.
+
+Given the below example:
+
+.. code:: python
+	
+	ubq = UpdateByQuery().using(client).script(source="ctx._source.likes++").script(source="ctx._source.likes+=2")
+
+This means that the stored script by this client will be ``'source': 'ctx._source.likes+=2'`` and the previous call
+will not be stored.
+
+For debugging purposes you can serialize the ``Update By Query`` object to a ``dict``
+explicitly:
+
+.. code:: python
+
+    print(ubq.to_dict())
+
+Serialization and Deserialization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The search object can be serialized into a dictionary by using the
+``.to_dict()`` method.
+
+You can also create a ``Update By Query`` object from a ``dict`` using the ``from_dict``
+class method. This will create a new ``Update By Query`` object and populate it using
+the data from the dict:
+
+.. code:: python
+
+  ubq = UpdateByQuery.from_dict({"query": {"match": {"title": "python"}}})
+
+If you wish to modify an existing ``Update By Query`` object, overriding it'ubq
+properties, instead use the ``update_from_dict`` method that alters an instance
+**in-place**:
+
+.. code:: python
+
+  ubq = UpdateByQuery(index='i')
+  ubq.update_from_dict({"query": {"match": {"title": "python"}}, "size": 42})
+
+Extra properties and parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To set extra properties of the search request, use the ``.extra()`` method.
+This can be used to define keys in the body that cannot be defined via a
+specific API method like ``explain``:
+
+.. code:: python
+
+  ubq = ubq.extra(explain=True)
+
+To set query parameters, use the ``.params()`` method:
+
+.. code:: python
+
+  ubq = ubq.params(routing="42")
+
+Response
+--------
+
+You can execute your search by calling the ``.execute()`` method that will return
+a ``Response`` object. The ``Response`` object allows you access to any key
+from the response dictionary via attribute access. It also provides some
+convenient helpers:
+
+.. code:: python
+
+  response = ubq.execute()
+
+  print(response.success())
+  # True
+
+  print(response.took)
+  # 12
+
+If you want to inspect the contents of the ``response`` objects, just use its
+``to_dict`` method to get access to the raw data for pretty printing.

--- a/elasticsearch_dsl/__init__.py
+++ b/elasticsearch_dsl/__init__.py
@@ -2,6 +2,7 @@ from .query import Q
 from .aggs import A
 from .function import SF
 from .search import Search, MultiSearch
+from .update_by_query import UpdateByQuery
 from .field import *
 from .document import Document, DocType, MetaField, InnerDoc
 from .mapping import Mapping

--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -1,5 +1,6 @@
 from .connections import connections
 from .search import Search
+from .update_by_query import UpdateByQuery
 from .exceptions import IllegalOperation
 from .mapping import Mapping
 from .utils import merge
@@ -228,6 +229,21 @@ class Index(object):
         ``Document``\\s.
         """
         return Search(
+            using=using or self._using,
+            index=self._name,
+            doc_type=self._doc_types
+        )
+
+    def updateByQuery(self, using=None):
+        """
+        Return a :class:`~elasticsearch_dsl.UpdateByQuery` object searching over the index
+        (or all the indices belonging to this template) and updating Documents that match
+        the search criteria.
+
+        For more information, see here:
+        https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html
+        """
+        return UpdateByQuery(
             using=using or self._using,
             index=self._name,
             doc_type=self._doc_types

--- a/elasticsearch_dsl/response/__init__.py
+++ b/elasticsearch_dsl/response/__init__.py
@@ -84,3 +84,16 @@ class AggResponse(AttrDict):
         for name in self._meta['aggs']:
             yield self[name]
 
+
+class UpdateByQueryResponse(AttrDict):
+
+    def __init__(self, search, response, doc_class=None):
+        super(AttrDict, self).__setattr__('_search', search)
+        super(AttrDict, self).__setattr__('_doc_class', doc_class)
+        super(UpdateByQueryResponse, self).__init__(response)
+
+    def __getitem__(self, attr_name):
+        return super(UpdateByQueryResponse, self).__getitem__(attr_name)
+
+
+

--- a/elasticsearch_dsl/update_by_query.py
+++ b/elasticsearch_dsl/update_by_query.py
@@ -99,8 +99,8 @@ class UpdateByQuery(Request):
         Example::
 
             ubq = Search()
-            ubq = ubq.script(source="ctx.__source.likes++"")
-            ubq = ubq.script(source="ctx.__source.likes += params.f"",
+            ubq = ubq.script(source="ctx._source.likes++"")
+            ubq = ubq.script(source="ctx._source.likes += params.f"",
                          lang="expression",
                          params={'f': 3})
         """

--- a/elasticsearch_dsl/update_by_query.py
+++ b/elasticsearch_dsl/update_by_query.py
@@ -133,8 +133,6 @@ class UpdateByQuery(Request):
         """
         Execute the search and return an instance of ``Response`` wrapping all
         the data.
-
-        :arg response_class: optional subclass of ``Response`` to use instead.
         """
         if ignore_cache or not hasattr(self, '_response'):
             es = connections.get_connection(self._using)

--- a/elasticsearch_dsl/update_by_query.py
+++ b/elasticsearch_dsl/update_by_query.py
@@ -1,5 +1,4 @@
 import copy
-from six import iteritems
 
 from .search import Request, QueryProxy, ProxyDescriptor
 from .query import Q, Bool
@@ -87,13 +86,6 @@ class UpdateByQuery(Request):
         d = d.copy()
         if 'query' in d:
             self.query._proxied = Q(d.pop('query'))
-
-        aggs = d.pop('aggs', d.pop('aggregations', {}))
-        if aggs:
-            self.aggs._params = {
-                'aggs': dict(
-                    (name, A(value)) for (name, value) in iteritems(aggs))
-            }
         if '_source' in d:
             self._source = d.pop('_source')
         if 'script' in d:

--- a/elasticsearch_dsl/update_by_query.py
+++ b/elasticsearch_dsl/update_by_query.py
@@ -1,0 +1,212 @@
+import copy
+from six import iteritems
+
+from .search import Request, QueryProxy, ProxyDescriptor
+from .query import Q, Bool
+from .response import UpdateByQueryResponse
+from .connections import connections
+
+class UpdateByQuery(Request):
+
+    query = ProxyDescriptor('query')
+
+    def __init__(self, **kwargs):
+        """
+        Update by query request to elasticsearch.
+
+        :arg using: `Elasticsearch` instance to use
+        :arg index: limit the search to index
+        :arg doc_type: only query this type.
+
+        All the parameters supplied (or omitted) at creation type can be later
+        overriden by methods (`using`, `index` and `doc_type` respectively).
+
+        """
+        super(UpdateByQuery, self).__init__(**kwargs)
+        self._response_class = UpdateByQueryResponse
+        self._source = None
+        self._script = {}
+        self._query_proxy = QueryProxy(self, 'query')
+
+    def filter(self, *args, **kwargs):
+        return self.query(Bool(filter=[Q(*args, **kwargs)]))
+
+    def exclude(self, *args, **kwargs):
+        return self.query(Bool(filter=[~Q(*args, **kwargs)]))
+
+    @classmethod
+    def from_dict(cls, d):
+        """
+        Construct a new `UpdateByQuery` instance from a raw dict containing the search
+        body. Useful when migrating from raw dictionaries.
+
+        Example::
+
+            ubq = UpdateByQuery.from_dict({
+                "query": {
+                    "bool": {
+                        "must": [...]
+                    }
+                },
+                "script": {...}
+            })
+            ubq = ubq.filter('term', published=True)
+        """
+        u = cls()
+        u.update_from_dict(d)
+        return u
+
+    def _clone(self):
+        """
+        Return a clone of the current search request. Performs a shallow copy
+        of all the underlying objects. Used internally by most state modifying
+        APIs.
+        """
+        ubq = super(UpdateByQuery, self)._clone()
+
+        ubq._response_class = self._response_class
+        ubq._source = copy.copy(self._source) \
+            if self._source is not None else None
+        ubq._script = self._script.copy()
+        getattr(ubq, 'query')._proxied = getattr(self, 'query')._proxied
+        return ubq
+
+    def response_class(self, cls):
+        """
+        Override the default wrapper used for the response.
+        """
+        ubq = self._clone()
+        ubq._response_class = cls
+        return ubq
+
+    def update_from_dict(self, d):
+        """
+        Apply options from a serialized body to the current instance. Modifies
+        the object in-place. Used mostly by ``from_dict``.
+        """
+        d = d.copy()
+        if 'query' in d:
+            self.query._proxied = Q(d.pop('query'))
+
+        aggs = d.pop('aggs', d.pop('aggregations', {}))
+        if aggs:
+            self.aggs._params = {
+                'aggs': dict(
+                    (name, A(value)) for (name, value) in iteritems(aggs))
+            }
+        if '_source' in d:
+            self._source = d.pop('_source')
+        if 'script' in d:
+            self._script = d.pop('script')
+        self._extra = d
+        return self
+
+    def script(self, **kwargs):
+        """
+        Define update action to take:
+        https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-using.html
+        for more details.
+
+        Note: the API only accepts a single script, so calling the script multiple times will overwrite.
+
+        Example::
+
+            ubq = Search()
+            ubq = ubq.script(source="ctx.__source.likes++"")
+            ubq = ubq.script(source="ctx.__source.likes += params.f"",
+                         lang="expression",
+                         params={'f': 3})
+        """
+        ubq = self._clone()
+        if ubq._script:
+            ubq._script = {}
+        ubq._script.update(kwargs)
+        return ubq
+
+    def source(self, fields=None, **kwargs):
+        """
+        Selectively control how the _source field is returned.
+
+        :arg source: wildcard string, array of wildcards, or dictionary of includes and excludes
+
+        If ``source`` is None, the entire document will be returned for
+        each hit.  If source is a dictionary with keys of 'include' and/or
+        'exclude' the fields will be either included or excluded appropriately.
+
+        Calling this multiple times with the same named parameter will override the
+        previous values with the new ones.
+
+        Example::
+
+            ubq = Search()
+            ubq = ubq.source(include=['obj1.*'], exclude=["*.description"])
+
+            ubq = Search()
+            ubq = ubq.source(include=['obj1.*']).source(exclude=["*.description"])
+
+        """
+        ubq = self._clone()
+
+        if fields and kwargs:
+            raise ValueError("You cannot specify fields and kwargs at the same time.")
+
+        if fields is not None:
+            ubq._source = fields
+            return ubq
+
+        if kwargs and not isinstance(ubq._source, dict):
+            ubq._source = {}
+
+        for key, value in kwargs.items():
+            if value is None:
+                try:
+                    del ubq._source[key]
+                except KeyError:
+                    pass
+            else:
+                ubq._source[key] = value
+
+        return ubq
+
+    def to_dict(self, **kwargs):
+        """
+        Serialize the search into the dictionary that will be sent over as the
+        request'ubq body.
+
+        All additional keyword arguments will be included into the dictionary.
+        """
+        d = {}
+        if self.query:
+            d["query"] = self.query.to_dict()
+
+        if self._source not in (None, {}):
+            d['_source'] = self._source
+
+        if self._script:
+            d['script'] = self._script
+
+        d.update(self._extra)
+
+        d.update(kwargs)
+        return d
+
+    def execute(self, ignore_cache=False):
+        """
+        Execute the search and return an instance of ``Response`` wrapping all
+        the data.
+
+        :arg response_class: optional subclass of ``Response`` to use instead.
+        """
+        if ignore_cache or not hasattr(self, '_response'):
+            es = connections.get_connection(self._using)
+
+            self._response = self._response_class(
+                self,
+                es.update_by_query(
+                    index=self._index,
+                    doc_type=self._get_doc_type(),
+                    body=self.to_dict(),
+                    **self._params
+                )
+            )
+        return self._response

--- a/test_elasticsearch_dsl/test_integration/test_update_by_query.py
+++ b/test_elasticsearch_dsl/test_integration/test_update_by_query.py
@@ -1,8 +1,6 @@
 from elasticsearch_dsl.update_by_query import UpdateByQuery
 from elasticsearch_dsl.search import Q
 
-
-
 def test_update_by_query_no_script(data_client):
     ubq = UpdateByQuery(using=data_client).index('git').filter(~Q('exists', field='is_public'))
     response = ubq.execute()
@@ -13,20 +11,16 @@ def test_update_by_query_no_script(data_client):
     assert response['updated'] == 52
     assert response['deleted'] == 0
 
-
 def test_update_by_query_with_script(data_client):
     ubq = UpdateByQuery(using=data_client).index('git')\
         .filter(~Q('exists', field='parent_shas'))\
         .script(source=f'ctx._source.is_public = false')
     ubq = ubq.params(conflicts='proceed')
 
-
     response = ubq.execute()
-
     assert response['total'] == 2
     assert response['updated'] == 1
     assert response['version_conflicts'] == 1
-
 
 def test_delete_by_query_with_script(data_client):
     ubq = UpdateByQuery(using=data_client).index('flat-git')\

--- a/test_elasticsearch_dsl/test_integration/test_update_by_query.py
+++ b/test_elasticsearch_dsl/test_integration/test_update_by_query.py
@@ -5,11 +5,12 @@ def test_update_by_query_no_script(data_client):
     ubq = UpdateByQuery(using=data_client).index('git').filter(~Q('exists', field='is_public'))
     response = ubq.execute()
 
-    assert response['total'] == 52
+    assert response.total == 52
     assert response['took'] > 0
-    assert not response['timed_out']
-    assert response['updated'] == 52
-    assert response['deleted'] == 0
+    assert not response.timed_out
+    assert response.updated == 52
+    assert response.deleted == 0
+    assert response.took > 0
 
 def test_update_by_query_with_script(data_client):
     ubq = UpdateByQuery(using=data_client).index('git')\
@@ -18,9 +19,9 @@ def test_update_by_query_with_script(data_client):
     ubq = ubq.params(conflicts='proceed')
 
     response = ubq.execute()
-    assert response['total'] == 2
-    assert response['updated'] == 1
-    assert response['version_conflicts'] == 1
+    assert response.total == 2
+    assert response.updated == 1
+    assert response.version_conflicts == 1
 
 def test_delete_by_query_with_script(data_client):
     ubq = UpdateByQuery(using=data_client).index('flat-git')\
@@ -30,5 +31,5 @@ def test_delete_by_query_with_script(data_client):
 
     response = ubq.execute()
 
-    assert response['total'] == 1
-    assert response['deleted'] == 1
+    assert response.total == 1
+    assert response.deleted == 1

--- a/test_elasticsearch_dsl/test_integration/test_update_by_query.py
+++ b/test_elasticsearch_dsl/test_integration/test_update_by_query.py
@@ -15,7 +15,7 @@ def test_update_by_query_no_script(data_client):
 def test_update_by_query_with_script(data_client):
     ubq = UpdateByQuery(using=data_client).index('git')\
         .filter(~Q('exists', field='parent_shas'))\
-        .script(source=f'ctx._source.is_public = false')
+        .script(source='ctx._source.is_public = false')
     ubq = ubq.params(conflicts='proceed')
 
     response = ubq.execute()
@@ -26,7 +26,7 @@ def test_update_by_query_with_script(data_client):
 def test_delete_by_query_with_script(data_client):
     ubq = UpdateByQuery(using=data_client).index('flat-git')\
         .filter(Q('match', parent_shas='1dd19210b5be92b960f7db6f66ae526288edccc3'))\
-        .script(source=f'ctx.op = "delete"')
+        .script(source='ctx.op = "delete"')
     ubq = ubq.params(conflicts='proceed')
 
     response = ubq.execute()

--- a/test_elasticsearch_dsl/test_integration/test_update_by_query.py
+++ b/test_elasticsearch_dsl/test_integration/test_update_by_query.py
@@ -1,0 +1,40 @@
+from elasticsearch_dsl.update_by_query import UpdateByQuery
+from elasticsearch_dsl.search import Q
+
+
+
+def test_update_by_query_no_script(data_client):
+    ubq = UpdateByQuery(using=data_client).index('git').filter(~Q('exists', field='is_public'))
+    response = ubq.execute()
+
+    assert response['total'] == 52
+    assert response['took'] > 0
+    assert not response['timed_out']
+    assert response['updated'] == 52
+    assert response['deleted'] == 0
+
+
+def test_update_by_query_with_script(data_client):
+    ubq = UpdateByQuery(using=data_client).index('git')\
+        .filter(~Q('exists', field='parent_shas'))\
+        .script(source=f'ctx._source.is_public = false')
+    ubq = ubq.params(conflicts='proceed')
+
+
+    response = ubq.execute()
+
+    assert response['total'] == 2
+    assert response['updated'] == 1
+    assert response['version_conflicts'] == 1
+
+
+def test_delete_by_query_with_script(data_client):
+    ubq = UpdateByQuery(using=data_client).index('flat-git')\
+        .filter(Q('match', parent_shas='1dd19210b5be92b960f7db6f66ae526288edccc3'))\
+        .script(source=f'ctx.op = "delete"')
+    ubq = ubq.params(conflicts='proceed')
+
+    response = ubq.execute()
+
+    assert response['total'] == 1
+    assert response['deleted'] == 1

--- a/test_elasticsearch_dsl/test_update_by_query.py
+++ b/test_elasticsearch_dsl/test_update_by_query.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from elasticsearch_dsl import UpdateByQuery, query, Q, Document
 
 
-# All of the basic query testing for Search can be copied over here and re-used
+# A lot of the basic query testing for Search can be copied over here and re-used
 def test_expand__to_dot_is_respected():
     ubq = UpdateByQuery().query('match', a__b=42, _expand__to_dot=False)
 
@@ -72,22 +72,9 @@ def test_query_always_returns_ubq():
 
     assert isinstance(ubq.query('match', f=42), UpdateByQuery)
 
-def test_source_copied_on_clone():
-    ubq = UpdateByQuery().source(False)
-    assert ubq._clone()._source == ubq._source
-    assert ubq._clone()._source is False
-
-    ubq2 = UpdateByQuery().source([])
-    assert ubq2._clone()._source == ubq2._source
-    assert ubq2._source == []
-
-    ubq3 = UpdateByQuery().source(["some", "fields"])
-    assert ubq3._clone()._source == ubq3._source
-    assert ubq3._clone()._source == ["some", "fields"]
-
 def test_copy_clones():
     from copy import copy
-    ubq1 = UpdateByQuery().source(["some", "fields"])
+    ubq1 = UpdateByQuery().query('match', f=42)
     ubq2 = copy(ubq1)
 
     assert ubq1 == ubq2
@@ -258,52 +245,6 @@ def test_params_being_passed_to_search(mock_client):
         body={},
         routing='42'
     )
-
-def test_source():
-    assert {} == UpdateByQuery().source().to_dict()
-
-    assert {
-        '_source': {
-            'include': ['foo.bar.*'],
-            'exclude': ['foo.one']
-        }
-    } == UpdateByQuery().source(include=['foo.bar.*'], exclude=['foo.one']).to_dict()
-
-    assert {
-        '_source': False
-    } == UpdateByQuery().source(False).to_dict()
-
-    assert {
-        '_source': ['f1', 'f2']
-    } == UpdateByQuery().source(include=['foo.bar.*'], exclude=['foo.one']).source(['f1', 'f2']).to_dict()
-
-def test_source_on_clone():
-    assert {
-        '_source': {
-            'include': ['foo.bar.*'],
-            'exclude': ['foo.one']
-        },
-        'query': {
-            'bool': {
-                'filter': [{'term': {'title': 'python'}}],
-            }
-        }
-    } == UpdateByQuery().source(include=['foo.bar.*']).\
-        source(exclude=['foo.one']).\
-        filter('term', title='python').to_dict()\
-
-    assert {'_source': False,
-            'query': {
-                'bool': {
-                    'filter': [{'term': {'title': 'python'}}],
-                }
-            }} == UpdateByQuery().source(
-        False).filter('term', title='python').to_dict()
-
-def test_source_on_clear():
-    assert {
-    } == UpdateByQuery().source(include=['foo.bar.*']).\
-        source(include=None, exclude=None).to_dict()
 
 def test_exclude():
     ubq = UpdateByQuery()

--- a/test_elasticsearch_dsl/test_update_by_query.py
+++ b/test_elasticsearch_dsl/test_update_by_query.py
@@ -1,8 +1,6 @@
 from copy import deepcopy
 
-from elasticsearch_dsl import UpdateByQuery, query, Q, Document, utils
-
-from pytest import raises
+from elasticsearch_dsl import UpdateByQuery, query, Q, Document
 
 
 # All of the basic query testing for Search can be copied over here and re-used
@@ -11,19 +9,16 @@ def test_expand__to_dot_is_respected():
 
     assert {"query": {"match": {"a__b": 42}}} == ubq.to_dict()
 
-
 def test_cache_isnt_cloned():
     ubq = UpdateByQuery()
     ubq._response = object()
 
     assert not hasattr(ubq._clone(), '_response')
 
-
 def test_ubq_starts_with_no_query():
     ubq = UpdateByQuery()
 
     assert ubq.query._proxied is None
-
 
 def test_ubq_combines_query():
     ubq = UpdateByQuery()
@@ -36,7 +31,6 @@ def test_ubq_combines_query():
     assert ubq2.query._proxied == query.Match(f=42)
     assert ubq3.query._proxied == query.Bool(must=[query.Match(f=42), query.Match(f=43)])
 
-
 def test_query_can_be_assigned_to():
     ubq = UpdateByQuery()
 
@@ -44,7 +38,6 @@ def test_query_can_be_assigned_to():
     ubq.query = q
 
     assert ubq.query._proxied is q
-
 
 def test_query_can_be_wrapped():
     ubq = UpdateByQuery().query('match', title='python')
@@ -58,8 +51,7 @@ def test_query_can_be_wrapped():
                 'query': {'match': {'title': 'python'}}
             }
         }
-    }== ubq.to_dict()
-
+    } == ubq.to_dict()
 
 def test_using():
     o = object()
@@ -70,12 +62,10 @@ def test_using():
     assert ubq._using is o
     assert ubq2._using is o2
 
-
 def test_methods_are_proxied_to_the_query():
     ubq = UpdateByQuery().query('match_all')
 
     assert ubq.query.to_dict() == {'match_all': {}}
-
 
 def test_query_always_returns_ubq():
     ubq = UpdateByQuery()
@@ -151,7 +141,6 @@ def test_ubq_doc_type():
     assert ubq._doc_type == ['i', 'i2']
     assert ubq2._doc_type == ['i', 'i2', 'i3']
 
-
 def test_doc_type_can_be_document_class():
     class MyDocument(Document):
         pass
@@ -166,7 +155,6 @@ def test_doc_type_can_be_document_class():
     assert ubq._doc_type_map == {}
     assert ubq._get_doc_type() == ['doc']
 
-
 def test_search_to_dict():
     ubq = UpdateByQuery()
     assert {} == ubq.to_dict()
@@ -178,7 +166,6 @@ def test_search_to_dict():
 
     ubq = UpdateByQuery(extra={"size": 5})
     assert {"size": 5} == ubq.to_dict()
-
 
 def test_complex_example():
     ubq = UpdateByQuery()
@@ -214,7 +201,6 @@ def test_complex_example():
             }
         }
     } == ubq.to_dict()
-
 
 def test_reverse():
     d =  {
@@ -254,14 +240,12 @@ def test_reverse():
     assert d == d2
     assert d == ubq.to_dict()
 
-
 def test_from_dict_doesnt_need_query():
     ubq = UpdateByQuery.from_dict({'script': {'source': 'test'}})
 
     assert {
         'script': {'source': 'test'}
     } == ubq.to_dict()
-
 
 def test_params_being_passed_to_search(mock_client):
     ubq = UpdateByQuery(using='mock')
@@ -274,7 +258,6 @@ def test_params_being_passed_to_search(mock_client):
         body={},
         routing='42'
     )
-
 
 def test_source():
     assert {} == UpdateByQuery().source().to_dict()
@@ -293,7 +276,6 @@ def test_source():
     assert {
         '_source': ['f1', 'f2']
     } == UpdateByQuery().source(include=['foo.bar.*'], exclude=['foo.one']).source(['f1', 'f2']).to_dict()
-
 
 def test_source_on_clone():
     assert {
@@ -318,12 +300,10 @@ def test_source_on_clone():
             }} == UpdateByQuery().source(
         False).filter('term', title='python').to_dict()
 
-
 def test_source_on_clear():
     assert {
     } == UpdateByQuery().source(include=['foo.bar.*']).\
         source(include=None, exclude=None).to_dict()
-
 
 def test_exclude():
     ubq = UpdateByQuery()
@@ -360,6 +340,6 @@ def test_overwrite_script():
     ubq = ubq.script(source='ctx._source.likes++')
     assert {
         'script': {
-            'source': 'ctx._source,likes++'
+            'source': 'ctx._source.likes++'
+        }
     } == ubq.to_dict()
-    }

--- a/test_elasticsearch_dsl/test_update_by_query.py
+++ b/test_elasticsearch_dsl/test_update_by_query.py
@@ -1,0 +1,365 @@
+from copy import deepcopy
+
+from elasticsearch_dsl import UpdateByQuery, query, Q, Document, utils
+
+from pytest import raises
+
+
+# All of the basic query testing for Search can be copied over here and re-used
+def test_expand__to_dot_is_respected():
+    ubq = UpdateByQuery().query('match', a__b=42, _expand__to_dot=False)
+
+    assert {"query": {"match": {"a__b": 42}}} == ubq.to_dict()
+
+
+def test_cache_isnt_cloned():
+    ubq = UpdateByQuery()
+    ubq._response = object()
+
+    assert not hasattr(ubq._clone(), '_response')
+
+
+def test_ubq_starts_with_no_query():
+    ubq = UpdateByQuery()
+
+    assert ubq.query._proxied is None
+
+
+def test_ubq_combines_query():
+    ubq = UpdateByQuery()
+
+    ubq2 = ubq.query('match', f=42)
+    assert ubq2.query._proxied == query.Match(f=42)
+    assert ubq.query._proxied is None
+
+    ubq3 = ubq2.query('match', f=43)
+    assert ubq2.query._proxied == query.Match(f=42)
+    assert ubq3.query._proxied == query.Bool(must=[query.Match(f=42), query.Match(f=43)])
+
+
+def test_query_can_be_assigned_to():
+    ubq = UpdateByQuery()
+
+    q = Q('match', title='python')
+    ubq.query = q
+
+    assert ubq.query._proxied is q
+
+
+def test_query_can_be_wrapped():
+    ubq = UpdateByQuery().query('match', title='python')
+
+    ubq.query = Q('function_score', query=ubq.query, field_value_factor={'field': 'rating'})
+
+    assert {
+        'query': {
+            'function_score': {
+                'functions': [{'field_value_factor': {'field': 'rating'}}],
+                'query': {'match': {'title': 'python'}}
+            }
+        }
+    }== ubq.to_dict()
+
+
+def test_using():
+    o = object()
+    o2 = object()
+    ubq = UpdateByQuery(using=o)
+    assert ubq._using is o
+    ubq2 = ubq.using(o2)
+    assert ubq._using is o
+    assert ubq2._using is o2
+
+
+def test_methods_are_proxied_to_the_query():
+    ubq = UpdateByQuery().query('match_all')
+
+    assert ubq.query.to_dict() == {'match_all': {}}
+
+
+def test_query_always_returns_ubq():
+    ubq = UpdateByQuery()
+
+    assert isinstance(ubq.query('match', f=42), UpdateByQuery)
+
+def test_source_copied_on_clone():
+    ubq = UpdateByQuery().source(False)
+    assert ubq._clone()._source == ubq._source
+    assert ubq._clone()._source is False
+
+    ubq2 = UpdateByQuery().source([])
+    assert ubq2._clone()._source == ubq2._source
+    assert ubq2._source == []
+
+    ubq3 = UpdateByQuery().source(["some", "fields"])
+    assert ubq3._clone()._source == ubq3._source
+    assert ubq3._clone()._source == ["some", "fields"]
+
+def test_copy_clones():
+    from copy import copy
+    ubq1 = UpdateByQuery().source(["some", "fields"])
+    ubq2 = copy(ubq1)
+
+    assert ubq1 == ubq2
+    assert ubq1 is not ubq2
+
+def test_ubq_index():
+    ubq = UpdateByQuery(index='i')
+    assert ubq._index == ['i']
+    ubq = ubq.index('i2')
+    assert ubq._index == ['i', 'i2']
+    ubq = ubq.index(u'i3')
+    assert ubq._index == ['i', 'i2', 'i3']
+    ubq = ubq.index()
+    assert ubq._index is None
+    ubq = UpdateByQuery(index=('i', 'i2'))
+    assert ubq._index == ['i', 'i2']
+    ubq = UpdateByQuery(index=['i', 'i2'])
+    assert ubq._index == ['i', 'i2']
+    ubq = UpdateByQuery()
+    ubq = ubq.index('i', 'i2')
+    assert ubq._index == ['i', 'i2']
+    ubq2 = ubq.index('i3')
+    assert ubq._index == ['i', 'i2']
+    assert ubq2._index == ['i', 'i2', 'i3']
+    ubq = UpdateByQuery()
+    ubq = ubq.index(['i', 'i2'], 'i3')
+    assert ubq._index == ['i', 'i2', 'i3']
+    ubq2 = ubq.index('i4')
+    assert ubq._index == ['i', 'i2', 'i3']
+    assert ubq2._index == ['i', 'i2', 'i3', 'i4']
+    ubq2 = ubq.index(['i4'])
+    assert ubq2._index == ['i', 'i2', 'i3', 'i4']
+    ubq2 = ubq.index(('i4', 'i5'))
+    assert ubq2._index == ['i', 'i2', 'i3', 'i4', 'i5']
+
+def test_ubq_doc_type():
+    ubq = UpdateByQuery(doc_type='i')
+    assert ubq._doc_type == ['i']
+    ubq = ubq.doc_type('i2')
+    assert ubq._doc_type == ['i', 'i2']
+    ubq = ubq.doc_type()
+    assert ubq._doc_type == []
+    ubq = UpdateByQuery(doc_type=('i', 'i2'))
+    assert ubq._doc_type == ['i', 'i2']
+    ubq = UpdateByQuery(doc_type=['i', 'i2'])
+    assert ubq._doc_type == ['i', 'i2']
+    ubq = UpdateByQuery()
+    ubq = ubq.doc_type('i', 'i2')
+    assert ubq._doc_type == ['i', 'i2']
+    ubq2 = ubq.doc_type('i3')
+    assert ubq._doc_type == ['i', 'i2']
+    assert ubq2._doc_type == ['i', 'i2', 'i3']
+
+
+def test_doc_type_can_be_document_class():
+    class MyDocument(Document):
+        pass
+
+    ubq = UpdateByQuery(doc_type=MyDocument)
+    assert ubq._doc_type == [MyDocument]
+    assert ubq._doc_type_map == {}
+    assert ubq._get_doc_type() == ['doc']
+
+    ubq = UpdateByQuery().doc_type(MyDocument)
+    assert ubq._doc_type == [MyDocument]
+    assert ubq._doc_type_map == {}
+    assert ubq._get_doc_type() == ['doc']
+
+
+def test_search_to_dict():
+    ubq = UpdateByQuery()
+    assert {} == ubq.to_dict()
+
+    ubq = ubq.query('match', f=42)
+    assert {"query": {"match": {'f': 42}}} == ubq.to_dict()
+
+    assert {"query": {"match": {'f': 42}}, "size": 10} == ubq.to_dict(size=10)
+
+    ubq = UpdateByQuery(extra={"size": 5})
+    assert {"size": 5} == ubq.to_dict()
+
+
+def test_complex_example():
+    ubq = UpdateByQuery()
+    ubq = ubq.query('match', title='python') \
+        .query(~Q('match', title='ruby')) \
+        .filter(Q('term', category='meetup') | Q('term', category='conference')) \
+        .script(source='ctx._source.likes += params.f', lang='painless', params={'f': 3})
+
+    ubq.query.minimum_should_match = 2
+    assert {
+        'query': {
+            'bool': {
+                'filter': [
+                    {
+                        'bool': {
+                            'should': [
+                                {'term': {'category': 'meetup'}},
+                                {'term': {'category': 'conference'}}
+                            ]
+                        }
+                    }
+                ],
+                'must': [ {'match': {'title': 'python'}}],
+                'must_not': [{'match': {'title': 'ruby'}}],
+                'minimum_should_match': 2
+            }
+        },
+        'script': {
+            'source': 'ctx._source.likes += params.f',
+            'lang': 'painless',
+            'params': {
+                'f': 3
+            }
+        }
+    } == ubq.to_dict()
+
+
+def test_reverse():
+    d =  {
+        'query': {
+            'filtered': {
+                'filter': {
+                    'bool': {
+                        'should': [
+                            {'term': {'category': 'meetup'}},
+                            {'term': {'category': 'conference'}}
+                        ]
+                    }
+                },
+                'query': {
+                    'bool': {
+                        'must': [ {'match': {'title': 'python'}}],
+                        'must_not': [{'match': {'title': 'ruby'}}],
+                        'minimum_should_match': 2
+                    }
+                }
+            }
+        },
+        'script': {
+            'source': 'ctx._source.likes += params.f',
+            'lang': 'painless',
+            'params': {
+                'f': 3
+            }
+        }
+    }
+
+    d2 = deepcopy(d)
+
+    ubq = UpdateByQuery.from_dict(d)
+
+    # make sure we haven't modified anything in place
+    assert d == d2
+    assert d == ubq.to_dict()
+
+
+def test_from_dict_doesnt_need_query():
+    ubq = UpdateByQuery.from_dict({'script': {'source': 'test'}})
+
+    assert {
+        'script': {'source': 'test'}
+    } == ubq.to_dict()
+
+
+def test_params_being_passed_to_search(mock_client):
+    ubq = UpdateByQuery(using='mock')
+    ubq = ubq.params(routing='42')
+    ubq.execute()
+
+    mock_client.update_by_query.assert_called_once_with(
+        doc_type=[],
+        index=None,
+        body={},
+        routing='42'
+    )
+
+
+def test_source():
+    assert {} == UpdateByQuery().source().to_dict()
+
+    assert {
+        '_source': {
+            'include': ['foo.bar.*'],
+            'exclude': ['foo.one']
+        }
+    } == UpdateByQuery().source(include=['foo.bar.*'], exclude=['foo.one']).to_dict()
+
+    assert {
+        '_source': False
+    } == UpdateByQuery().source(False).to_dict()
+
+    assert {
+        '_source': ['f1', 'f2']
+    } == UpdateByQuery().source(include=['foo.bar.*'], exclude=['foo.one']).source(['f1', 'f2']).to_dict()
+
+
+def test_source_on_clone():
+    assert {
+        '_source': {
+            'include': ['foo.bar.*'],
+            'exclude': ['foo.one']
+        },
+        'query': {
+            'bool': {
+                'filter': [{'term': {'title': 'python'}}],
+            }
+        }
+    } == UpdateByQuery().source(include=['foo.bar.*']).\
+        source(exclude=['foo.one']).\
+        filter('term', title='python').to_dict()\
+
+    assert {'_source': False,
+            'query': {
+                'bool': {
+                    'filter': [{'term': {'title': 'python'}}],
+                }
+            }} == UpdateByQuery().source(
+        False).filter('term', title='python').to_dict()
+
+
+def test_source_on_clear():
+    assert {
+    } == UpdateByQuery().source(include=['foo.bar.*']).\
+        source(include=None, exclude=None).to_dict()
+
+
+def test_exclude():
+    ubq = UpdateByQuery()
+    ubq = ubq.exclude('match', title='python')
+
+    assert {
+        'query': {
+            'bool': {
+                'filter': [{
+                    'bool': {
+                        'must_not': [{
+                            'match': {
+                                'title': 'python'
+                            }
+                        }]
+                    }
+                }]
+            }
+        }
+    } == ubq.to_dict()
+
+def test_overwrite_script():
+    ubq = UpdateByQuery()
+    ubq = ubq.script(source='ctx._source.likes += params.f', lang='painless', params={'f': 3})
+    assert {
+        'script': {
+            'source': 'ctx._source.likes += params.f',
+            'lang': 'painless',
+            'params': {
+                'f': 3
+            }
+        }
+    } == ubq.to_dict()
+    ubq = ubq.script(source='ctx._source.likes++')
+    assert {
+        'script': {
+            'source': 'ctx._source,likes++'
+    } == ubq.to_dict()
+    }


### PR DESCRIPTION
1. Implemented UpdateByQuery object to execute the update_by_query endpoint.
2. Added unit and integration tests 
3. Updated docs with examples & description of code additions.

Note: linting & typechecking do not match CBI standards.